### PR TITLE
Added tests to check legacy RIPEMD encoding and decoding

### DIFF
--- a/legacy/decode_test.go
+++ b/legacy/decode_test.go
@@ -1,12 +1,21 @@
 package legacy
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDecodeP2KH(t *testing.T) {
+	legacy, err := Decode("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
+	assert.Nil(t, err)
+	assert.Equal(t, legacy.Version, uint8(0))
+	expectedRipemd, _ := hex.DecodeString("010966776006953D5567439E5E39F86A0D273BEE")
+	assert.Equal(t, expectedRipemd, legacy.Payload, "Error decoding address payloads")
+}
+
+func TestDecodeP2KHLegacyAndCopayLegacy(t *testing.T) {
 	legacy, err := Decode("19NoN69ntmV9nKHBjArLJXXCNq3AvvMsqG")
 	assert.Nil(t, err)
 	copay, err := Decode("CQqgw8VrmpTggTBcQvBFt39DzxFavppafB")
@@ -16,7 +25,7 @@ func TestDecodeP2KH(t *testing.T) {
 	assert.Equal(t, copay.Payload, legacy.Payload, "Error decoding address payloads")
 }
 
-func TestDecodeP2SH(t *testing.T) {
+func TestDecodeP2SHLegacyAndCopayLegacy(t *testing.T) {
 	legacy, err := Decode("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
 	assert.Nil(t, err)
 	copay, err := Decode("HNyFLowu5sKhpYeSnQJmqBWFYWorHKAWDE")

--- a/legacy/encode_test.go
+++ b/legacy/encode_test.go
@@ -1,12 +1,24 @@
 package legacy
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToLegacyP2KH(t *testing.T) {
+func TestEncodeP2KH(t *testing.T) {
+	payload, _ := hex.DecodeString("010966776006953D5567439E5E39F86A0D273BEE")
+	legacy := &Address{
+		Version: P2KH,
+		Payload: payload,
+	}
+	address, err := legacy.Encode()
+	assert.Nil(t, err)
+	assert.Equal(t, "16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM", address, "Conversion failed")
+}
+
+func TestEncodeLegacyToCopayLegacyP2KH(t *testing.T) {
 	legacy, err := Decode("19NoN69ntmV9nKHBjArLJXXCNq3AvvMsqG")
 	assert.Nil(t, err)
 	legacy.Version = P2KHCopay
@@ -16,7 +28,7 @@ func TestToLegacyP2KH(t *testing.T) {
 
 }
 
-func TestToLegacyP2SH(t *testing.T) {
+func TestEncodeLegacyToCopayLegacyP2SH(t *testing.T) {
 	legacy, err := Decode("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
 	assert.Nil(t, err)
 	legacy.Version = P2SHCopay


### PR DESCRIPTION
I wanted to make sure we had some tests double-checking encoding from the RIPEMD hash, otherwise it's theoretically possible for the encoding <-> decoding code to be buggy but still pass the existing tests since the decoding tests call encoding code and vice versa.