### PR TITLE
Cashaddr uppercase decode support

### DIFF
--- a/cashaddress/decode.go
+++ b/cashaddress/decode.go
@@ -42,7 +42,7 @@ func Decode(addr string, defaultPrefix string) (*Address, error) {
 	}
 
 	// Unpack the address without the checksum bits
-	raw, err := unpackAddress(decoded[:len(decoded)-8], prefix)
+	raw, err := unpackAddress(decoded[:len(decoded)-8], strings.ToLower(prefix))
 	return raw, err
 }
 


### PR DESCRIPTION
There is an issue when decoding a cashaddr that is all uppercase `invalid address network`
The decode method is working fine, but when `NewFromCashAddress` (rawaddr.go) wants to check what kind of prefix the address has to define the network, it always compare the string with the ones the ones defined as const (that are all lowercase).
```
    switch addr.Prefix {
	case cashaddress.MainNet:
		network = MainNet
	case cashaddress.TestNet:
		network = TestNet
	case cashaddress.RegTest:
		network = RegTest
	default:
		return nil, errors.New("invalid address network")
	}
```

This is a quick fix that makes the decode method to returns the prefix in lowercase so it can be compared with ones defined.
